### PR TITLE
ADR 80  CEE diagnostic gathering mechanism

### DIFF
--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -6,13 +6,15 @@ authors:
   - "Keith Wall"
 ---
 
+include::/_includes/glossary_links.adoc[]
+
 ## Context and Problem Statement
 
-In order to provide support to the customers of a Managed Service, a company offering the Managed Service will typically have a Support
-Organisation (SO) dedicated to this function.  In order to perform this function effectively the SO requires a mechanism that allows
-them to capture the state of the instance of the service for diagnostic purposes.
+In order to provide support to the customers of a Managed Service, a company offering the Managed Service will typically have a {glossary-customersupport}
+organisation.  In order to assist the customers, members of {glossary-customersupport} require a mechanism that allows them to capture the state of the
+instance of the service for diagnostic purposes.
 
-The SO will use the gathered information in conjunction with the problem statement provided by the customer in order to efficiently
+{glossary-customersupport} will use the gathered information in conjunction with the problem statement provided by the customer in order to efficiently
 investigate the problem and determine a solution.
 
 The data gathering mechanism must consider the issue of Personally Identifiable Information (PII) or other sensitive information and ensure
@@ -31,10 +33,9 @@ permissioned groups.
 None
 
 ## Stakeholders
-* Eng
-* BU
-* SRE
-* SO
+* {glossary-businessstakeholder}
+* {glossary-sre}
+* {glossary-customersupport}
 
 ## Current Architecture
 
@@ -47,7 +48,7 @@ https://datatracker.ietf.org/doc/html/rfc2119[RFC-2119] keywords are used in thi
 It is RECOMMENDED that managed services use https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_scripts[Back Plane]
 https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the data gathering mechanism. Backplane has an
 established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_cluster_permissions[authorization model] that ensures
-that members of the SO have the permissions to run the scripts.
+that members of the {glossary-customersupport} have the permissions to run the scripts.
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -66,14 +66,12 @@ The scripts MUST be non-mutating in nature.
 
 ### Threat Model
 
-* <Provide a link to the relevant threat model. You must either update an existing threat model(s) to cover the changes made by this ADR, or add a new threat model.
-
-* Take a copy of the threat model when the ADR is proposed, and merge those changes in once the ADR is accepted
+This ADR does not alert the threat model.
 
 ## Alternatives Considered / Rejected
 
-The option of providing an OpenShift MustGather Image was considered, however, as the approved access mechanism to the data-plane is backplane,
-utilising the backplane managed-scripts feature to perform the data gathering step minimised dependencies.
+The option of providing an https://access.redhat.com/articles/4591521[OpenShift MustGather Image] was considered, however, as the approved access
+mechanism to the data-plane is backplane, utilising the backplane managed-scripts feature to perform the data gathering step minimised dependencies.
 
 ## Challenges
 

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -46,7 +46,7 @@ It is RECOMMENDED that managed services use https://source.redhat.com/groups/pub
 https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the  data gathering mechanism. Backplane has an 
 established authorization model that ensures that CEE have the permissions to run the scripts (KW: how does this work)?
 
-Each Managed Service that implements this ADR MUST provide one or more backplane scripts that the interrogate the state of a service instance.
+Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
 RECOMMENEDED that the scropt invoke the `oc adm inspect` command to gather than Kubernetes state in addition to any other service specific
 state gathering commands.

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -48,7 +48,7 @@ https://datatracker.ietf.org/doc/html/rfc2119[RFC-2119] keywords are used in thi
 It is RECOMMENDED that managed services use https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_scripts[Back Plane]
 https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the data gathering mechanism. Backplane has an
 established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_cluster_permissions[authorization model] that ensures
-that members of the {glossary-customersupport} have the permissions to run the scripts.
+that members of {glossary-customersupport} have the permissions to run the scripts.
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -51,14 +51,14 @@ established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/ba
 that members of {glossary-customersupport} have the permissions to run the scripts.
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
-The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
-RECOMMENDED that the script invoke the `oc adm inspect` command to gather Kubernetes state in addition to any other service specific
+The exact way way the scripts will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
+RECOMMENDED that the scripts invoke the `oc adm inspect` command to gather Kubernetes state in addition to any other service specific
 state gathering commands.
 
-It is RECOMMENDED that the output from the backplane script be a UNIX tar stream.  This will allow the artifact to provide the diagnostic
+It is RECOMMENDED that the output from the scripts be a UNIX tar stream.  This will allow the artifact to provide the diagnostic
 information in a structured form that can easily be processed using common command-line tools.
 
-It is RECOMMENDED that the script takes reasonable steps to avoid the collection of PII or other sensitive information. This may be done
+It is RECOMMENDED that the scripts takes reasonable steps to avoid the collection of PII or other sensitive information. This may be done
 either by redacting artifacts known to contain secrets/keys etc, or not gathering certain information in the first place.  For
 example, in a Java based system where PII may be present in the Java heap, the safe option is not to collect heap dumps.
 

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -12,13 +12,12 @@ In order to provide support to customers of a Managed Service, CEE require a mec
 state of the instance of the service for diagnostic purposes.  CEE will use this information in conjunction with the
 problem statement provided by the customer in order to efficiently investigate the problem and determine a solution.
 
-The data gathering mechanism must consider the issue of Personally Identifiable Information (PII) or other sensitive
-information and ensure that it is handled appropriately.
+The data gathering mechanism must consider the issue of
+https://source.redhat.com/departments/it/digitalsolutionsdelivery/enterprise-architecture/mojo_content/red_hat_data_classifications
+[Personally Identifiable Information (PII)] or other sensitive information and ensure that it is handled appropriately.
 
 Authorization controls must be in place to ensure that the diagnostic gathering mechanism can only be used by suitably
 permissioned groups.
-
-
 
 ## Goals
 
@@ -43,8 +42,9 @@ None
 https://datatracker.ietf.org/doc/html/rfc2119[RFC-2119] keywords are used in this proposal.
 
 It is RECOMMENDED that managed services use https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_scripts[Back Plane]
-https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the  data gathering mechanism. Backplane has an 
-established authorization model that ensures that CEE have the permissions to run the scripts (KW: how does this work)?
+https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the data gathering mechanism. Backplane has an
+established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_cluster_permissions[authorization model] that ensures that CEE
+have the permissions to run the scripts.
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
@@ -85,8 +85,7 @@ Poor customer experience when raising support-cases.
 
 ## References
 
-https://source.redhat.com/departments/it/digitalsolutionsdelivery/enterprise-architecture/mojo_content/red_hat_data_classifications
-https://access.redhat.com/solutions/6559791
+This https://access.redhat.com/solutions/6559791[support article] walks the reader through the backplane set-up required for members of CEE.
 
 
 

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -20,3 +20,73 @@ permissioned groups.
 
 
 
+## Goals
+
+* Identify the preferred solution for the diagnostic gathering mechanism.
+* Provide guidelines for content that should be included.
+
+## Non-goals
+
+None
+
+## Stakeholders
+* Eng
+* BU
+* SRE
+
+## Current Architecture
+
+None
+
+## Proposed Architecture
+
+https://datatracker.ietf.org/doc/html/rfc2119[RFC-2119] keywords are used in this proposal.
+
+It is RECOMMENDED that managed services use https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_scripts[Back Plane]
+https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the  data gathering mechanism. Backplane has an 
+established authorization model that ensures that CEE have the permissions to run the scripts (KW: how does this work)?
+
+Each Managed Service that implements this ADR MUST provide one or more backplane scripts that the interrogate the state of a service instance.
+The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
+RECOMMENEDED that the scropt invoke the `oc adm inspect` command to gather than Kubernetes state in addition to any other service specific
+state gathering commands.
+
+It is RECOMMENDED that the output from the backplane script be a UNIX tar stream.  This will allow the artifact to provide the diagnostic
+information in a structured form that can easily be processed using common command-line tools.
+
+The scripts MUST NOT gather PII or other sensitive information.  This may be done either by redacting artifacts known to contain secrets, or
+not gathering certain information in the first place.  For example, in a Java based system where PII may be present in the Java heap, the safe
+option is not to collect heap dumps.
+
+The scripts MUST be non-mutating in nature.
+
+### Threat Model
+
+* <Provide a link to the relevant threat model. You must either update an existing threat model(s) to cover the changes made by this ADR, or add a new threat model.
+
+* Take a copy of the threat model when the ADR is proposed, and merge those changes in once the ADR is accepted
+
+## Alternatives Considered / Rejected
+
+The option of providing an OpenShift MustGather Image was considered, however, as the approved access mechanism to the data-plane is backplane,
+utilising the backplane managed-scripts feature to perform the data gathering step minimised dependencies.
+
+## Challenges
+
+None.
+
+## Dependencies
+
+* None
+
+## Consequences if Not Completed
+
+Poor customer experience when raising support-cases.
+
+## References
+
+https://source.redhat.com/departments/it/digitalsolutionsdelivery/enterprise-architecture/mojo_content/red_hat_data_classifications
+https://access.redhat.com/solutions/6559791
+
+
+

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -48,7 +48,7 @@ established authorization model that ensures that CEE have the permissions to ru
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
-RECOMMENEDED that the scropt invoke the `oc adm inspect` command to gather than Kubernetes state in addition to any other service specific
+RECOMMENDED that the script invoke the `oc adm inspect` command to gather Kubernetes state in addition to any other service specific
 state gathering commands.
 
 It is RECOMMENDED that the output from the backplane script be a UNIX tar stream.  This will allow the artifact to provide the diagnostic

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -1,6 +1,6 @@
 ---
 num: 80
-title: "CEE diagnostic gathering mechanism"
+title: "Diagnostic Gathering"
 status: "Draft"
 authors:
   - "Keith Wall"
@@ -8,13 +8,15 @@ authors:
 
 ## Context and Problem Statement
 
-In order to provide support to customers of a Managed Service, CEE require a mechanism that allows them to capture the
-state of the instance of the service for diagnostic purposes.  CEE will use this information in conjunction with the
-problem statement provided by the customer in order to efficiently investigate the problem and determine a solution.
+In order to provide support to the customers of a Managed Service, a company offering the Managed Service will typically have a Support
+Organisation (SO) dedicated to this function.  In order to perform this function effectively the SO requires a mechanism that allows
+them to capture the state of the instance of the service for diagnostic purposes.
 
-The data gathering mechanism must consider the issue of
-https://source.redhat.com/departments/it/digitalsolutionsdelivery/enterprise-architecture/mojo_content/red_hat_data_classifications
-[Personally Identifiable Information (PII)] or other sensitive information and ensure that it is handled appropriately.
+The SO will use the gathered information in conjunction with the problem statement provided by the customer in order to efficiently
+investigate the problem and determine a solution.
+
+The data gathering mechanism must consider the issue of Personally Identifiable Information (PII) or other sensitive information and ensure
+that it is handled appropriately.
 
 Authorization controls must be in place to ensure that the diagnostic gathering mechanism can only be used by suitably
 permissioned groups.
@@ -32,6 +34,7 @@ None
 * Eng
 * BU
 * SRE
+* SO
 
 ## Current Architecture
 
@@ -43,8 +46,8 @@ https://datatracker.ietf.org/doc/html/rfc2119[RFC-2119] keywords are used in thi
 
 It is RECOMMENDED that managed services use https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_scripts[Back Plane]
 https://github.com/openshift/managed-scripts/[managed scripts] as the foundation of the data gathering mechanism. Backplane has an
-established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_cluster_permissions[authorization model] that ensures that CEE
-have the permissions to run the scripts.
+established https://source.redhat.com/groups/public/openshiftplatformsre/wiki/backplane_cluster_permissions[authorization model] that ensures
+that members of the SO have the permissions to run the scripts.
 
 Each Managed Service that implements this ADR MUST provide one or more backplane scripts that interrogate the state of a service instance.
 The exact way way the script will interrogate state will be service specific, however if the service provided on top of OpenShift, it is
@@ -82,10 +85,6 @@ None.
 ## Consequences if Not Completed
 
 Poor customer experience when raising support-cases.
-
-## References
-
-This https://access.redhat.com/solutions/6559791[support article] walks the reader through the backplane set-up required for members of CEE.
 
 
 

--- a/_adr/80/index.adoc
+++ b/_adr/80/index.adoc
@@ -57,9 +57,9 @@ state gathering commands.
 It is RECOMMENDED that the output from the backplane script be a UNIX tar stream.  This will allow the artifact to provide the diagnostic
 information in a structured form that can easily be processed using common command-line tools.
 
-The scripts MUST NOT gather PII or other sensitive information.  This may be done either by redacting artifacts known to contain secrets, or
-not gathering certain information in the first place.  For example, in a Java based system where PII may be present in the Java heap, the safe
-option is not to collect heap dumps.
+It is RECOMMENDED that the script takes reasonable steps to avoid the collection of PII or other sensitive information. This may be done
+either by redacting artifacts known to contain secrets/keys etc, or not gathering certain information in the first place.  For
+example, in a Java based system where PII may be present in the Java heap, the safe option is not to collect heap dumps.
 
 The scripts MUST be non-mutating in nature.
 


### PR DESCRIPTION
In order to provide support to customers of a Managed Service, CEE require a mechanism that allows them to capture the
state of the instance of the service for diagnostic purposes.  CEE will use this information in conjunction with the
problem statement provided by the customer in order to efficiently investigate the problem and determine a solution.

Managed Kafka has adopted backplane managed scripts as a solution to this problem. We want to propose it as a pattern.
