### PR TITLE
Update to Jekyll 4, fix some other things

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@ name: Build and deploy Jekyll site to GitHub Pages
 on:
   push:
     branches:
-      - main 
+      - main
 
 jobs:
   github-pages:
@@ -12,6 +12,15 @@ jobs:
       PAGES_REPO_NWO: bf2fc6cc711aee1a0c2a/architecture
     steps:
       - uses: actions/checkout@v2
+
+      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
       - uses: helaili/jekyll-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 .idea
 .vscode
 
+/.jekyll-cache/
+/.jekyll-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,7 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer
 # versions of the gem do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+# This is needed temporarily for the local container image, until
+# https://github.com/envygeeks/jekyll-docker/issues/335 is resolved.
+gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,25 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# gem "jekyll", "~> 4.2.1" # disabled per https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll
+gem "jekyll", "~> 4.2.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 219", group: :jekyll_plugins
+# gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'jekyll-asciidoc'
+  gem 'jekyll-coffeescript'
+  gem 'jekyll-default-layout'
+  gem 'jekyll-gist'
+  gem 'jekyll-github-metadata'
+  gem 'jekyll-optional-front-matter'
+  gem 'jekyll-paginate'
+  gem 'jekyll-readme-index'
+  gem 'jekyll-titles-from-headings'
+  gem 'jekyll-relative-links'
+  gem 'jekyll-avatar'
   gem "jekyll-feed", "~> 0.12"
 end
 
@@ -29,3 +39,6 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer
+# versions of the gem do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/README.adoc
+++ b/README.adoc
@@ -1,16 +1,15 @@
-# app-services-architecture
-
+= app-services-architecture
 
 Application Services Architecture Decision Records
 
-## Website
+== Website
 
 https://architecture.appservices.tech
 
 
-## Running Locally
+== Running Locally
 
-```
+----
 bundle install
 bundle exec jekyll serve
-```
+----

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,30 @@ https://architecture.appservices.tech
 
 == Running Locally
 
+[TIP]
+====
+The `jekyll-github-metadata` plugin will perform some API requests to GitHub, which can lead to rate-limiting warnings.
+To avoid seeing these, create a GitHub personal access token with `public_repo` scope, and set it as the value of the `JEKYLL_GITHUB_TOKEN` environment variable.
+====
+
+Building and running locally requires Ruby and bundler.
+You can either bring your own, or use the Jekyll container image.
+
+=== Bring your own Ruby & bundler
+
 ----
 bundle install
-bundle exec jekyll serve
+bundle exec jekyll serve --incremental
+----
+
+=== Using a container image with Podman or Docker
+
+----
+docker run -ti --rm \
+    -v .:/srv/jekyll \
+    -p 4000:4000 \
+    -e JEKYLL_ROOTLESS=1 \
+    -e JEKYLL_GITHUB_TOKEN \
+    docker.io/jekyll/jekyll \
+    jekyll serve --incremental
 ----

--- a/_adr/84/index.adoc
+++ b/_adr/84/index.adoc
@@ -39,13 +39,13 @@ An example of what a current SOP architecture looks like is the Red Hat OpenShif
 image::upstream_downstream_docs_pattern.png[Upstream/downstream]
 
 == Proposal
-The proposed solution is to follow a two repository model. One private repository that will contain SOPs that have the Red Hat internal information mentioned above, the other being a public repository that will have SOPs with the Red Hat internal information removed. This model will allow the SRE teams to use the private SOP repository without any information loss and allow upstream users to use and contribute to the SOP without breaching any Red Hat data policies. 
+The proposed solution is to follow a two repository model. One private repository that will contain SOPs that have the Red Hat internal information mentioned above, the other being a public repository that will have SOPs with the Red Hat internal information removed. This model will allow the SRE teams to use the private SOP repository without any information loss and allow upstream users to use and contribute to the SOP without breaching any Red Hat data policies.
 
 The content of the SOPs will be mirrored/synced between both repositories apart from the Red Hat internal information. The flow of contributing information to the repositories can be done both ways i.e from downstream to upstream and from upstream to downstream. This information can be contributed manually through the creation of pull requests or it can be done autonomously using the mirroring features in the repository. The team in charge of the SOPs will be responsible for maintaining the information between both repositories. This includes merging contributions from external users in the upstream repository and ensuring, if applicable, it gets added to the downstream repository and vice versa.
 
 SOPs from a private downstream repository that contain sensitive information, will have to be cleaned of all sensitive information before being pushed to the upstream public repository. Such information might be links to secrets or information about the managed service infrastructure etc. The pre-existing Structure of the SOPs should also be looked at, to see if any information can be removed that is no longer necessary or can be moved to a different internal location, this will help reduce overhead when syncing.
 
-=== Example implementation 
+=== Example implementation
 An example implementation of this model can be seen by the RHOSAK team through a ‘steel thread’ they are currently working on. They have implemented an internal downstream version of the SOPs repo in Gitlab, as it comes with asciidoc functionality that github does not provide. Such functionality is asciidoc includes, RHOSAK are using the includes functionality to extrapolate sensitive or repetitive information from the SOPs themselves and have the information in a separate config file that can be used across the SOPs. They will then be able to make the actual SOP asciidoc file available upstream but the sensitive information will not be included as the include config file will not be available upstream. Please see below for example code. The upstream SOPs repo will be located in Github and be public to external users. It will not contain any include config file so no sensitive information will be rendered. The include path will be present so external users can add their own include config file with their own information if they choose to do so.
 
 
@@ -57,7 +57,6 @@ An example implementation of this model can be seen by the RHOSAK team through a
 . Step 3: Reset the configuration
 
 If you're still having trouble, check out the generic link:troubleshooting.html[Troubleshooting] doc
-include::config.adoc[tag=contact-eng]
 ----
 
 ==== Example asciidoc includes config file
@@ -70,21 +69,21 @@ If all documented procedures have been followed and all avenues of troubleshooti
 ==== Example of rendered private SOP:
 image::private_downstream.png[Upstream/downstream]
 
-==== Example of rendered public SOP: 
+==== Example of rendered public SOP:
 
 image::public upstream.png[Upstream/downstream]
 
 == Threat model
 * Does open-sourcing our SOPs give an attacker information that could be helpful to them in compromising our service?
- 
+
 == Alternatives Considered / Rejected
-* Not having a open sourced SOPs repo: 
+* Not having a open sourced SOPs repo:
 ** Keeping the current most common architecture i.e Having a single private SOPs repo only. Rejected as managed services can not open source the SOPs
-* Github actions: 
+* Github actions:
 ** Using github actions and a renderer plugin to remove Red Hat internal information. This allows the ability to have SOPs without sensitive information. Rejected as there was a lot of extra work and overhead needed to get this option working.
 
 == Challenges
-Most existing managed services that have pre existing SOPs in a private repo that want to adopt this model, will have to migrate their current SOPs to the upstream public repository. These SOPs may have content already that would need to be stripped back or cleaned for the upstream repo. 
+Most existing managed services that have pre existing SOPs in a private repo that want to adopt this model, will have to migrate their current SOPs to the upstream public repository. These SOPs may have content already that would need to be stripped back or cleaned for the upstream repo.
 
 The overhead of having to maintain two separate repos, ensuring that neither become out of sync or become unusable and out of date.
 Dependencies

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-
 # Welcome to Jekyll!
 #
 # This config file is meant for settings that affect your whole blog, values
@@ -9,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -22,8 +21,8 @@
 title: Application Services Architecture
 email: mk-support@redhat.com
 description: >- # this means to ignore newlines until "baseurl:"
-  This site contains resources about the architecture and processes for 
-  Red Hat Application Services. 
+  This site contains resources about the architecture and processes for
+  Red Hat Application Services.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://architecture.appservices.tech" # the base hostname & protocol for your site, e.g. http://example.com
 #twitter_username: jekyllrb
@@ -57,8 +56,8 @@ collections:
 
 include:
  - CNAME
- 
- 
+
+
  # Workaround: See https://github.com/redhat-developer/app-services-architecture/pull/11
 github:
   repository_url: https://github.com/redhat-developer/app-services-architecture

--- a/_config.yml
+++ b/_config.yml
@@ -57,12 +57,6 @@ collections:
 include:
  - CNAME
 
-
- # Workaround: See https://github.com/redhat-developer/app-services-architecture/pull/11
-github:
-  repository_url: https://github.com/redhat-developer/app-services-architecture
-
-
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/pages/about/adr-process.adoc
+++ b/pages/about/adr-process.adoc
@@ -3,26 +3,27 @@ layout: page
 title: About
 permalink: /about/adr-process
 layout: default
+liquid: true
 ---
 
 == Github Process
 
 === Proposed ADRs
 
-If you identify the need for an ADR please {{site.github.repository_url}}/issues/new[open an issue] describing the decision that needs to be taken.
+If you identify the need for an ADR please {{ site.github.repository_url }}/issues/new[open an issue] describing the decision that needs to be taken.
 
 The discussion of the issue should decide whether a new ADR really is needed.
 If so, it should also seek to identify.
 
-* Whether any {{site.url}}/padr/[platform ADRs] apply. 
-* What tags the ADR should have. 
-* What the _summary_ of the new ADR should be. 
+* Whether any {{ site.url }}/padr/[platform ADRs] apply.
+* What tags the ADR should have.
+* What the _summary_ of the new ADR should be.
 
 === Drafting an ADR
 
-If, following discussion on the issue, an ADR really is called-for then open a PR to allocate an ADR id. 
+If, following discussion on the issue, an ADR really is called-for then open a PR to allocate an ADR id.
 
-This PR will add a `_adr/__nnnn__/index.adoc` file (where __nnnn__ is the ADR id) to the {{site.github.repository_name}} repo, giving your draft ADR an id. 
+This PR will add a `_adr/__nnnn__/index.adoc` file (where __nnnn__ is the ADR id) to the {{site.github.repository_name}} repo, giving your draft ADR an id.
 You can use the template in link:/adr/0/[`_adr/0/index.adoc`], so the steps to opening the PR are:
 
 . Fork {{site.github.repository_url}}[this repo] on github
@@ -30,14 +31,14 @@ You can use the template in link:/adr/0/[`_adr/0/index.adoc`], so the steps to o
 . Create a branch (`git checkout -b adr-__nnnn__`)
 . Create your ADR file from the template (`cp -r _adr/0 _adr/__nnnn__`)
 . Update your ADR file:
-  * If the issue identified any applicable PADRs the `applies_padrs` property should be added to the front matter. 
+  * If the issue identified any applicable PADRs the `applies_padrs` property should be added to the front matter.
   It's an array of all the applicable PADRs.
-  * If the issue identified and tags, the `tags` property should be added to the front matter. 
+  * If the issue identified and tags, the `tags` property should be added to the front matter.
   It's an array of tags.
-  * The only content of the ADR at this point will be the _summary_ that the ADR proposal issue produced. 
-. Push your branch (`git push origin adr-_nnnn_`) and {{site.github.repository_url}}/compare[open the PR] on github. 
+  * The only content of the ADR at this point will be the _summary_ that the ADR proposal issue produced.
+. Push your branch (`git push origin adr-_nnnn_`) and {{site.github.repository_url}}/compare[open the PR] on github.
 
-This PR should be merged immediately, and the original issue closed. 
+This PR should be merged immediately, and the original issue closed.
 
 === Writing an ADR
 
@@ -80,7 +81,7 @@ tags:
 Blah blah blah...
 ```
 
-`num`:: The ADR number. 
+`num`:: The ADR number.
 This is allocated when the ADR is first drafted and never changes thereafter.
 The next available id should be the largest id in the link:/adr/[ADR index] plus one.
 `title`:: The ADR's title. The `<h1>` title of the ADR is defined in the ADR template to be `{{num}}: {{title}}`
@@ -90,5 +91,5 @@ The next available id should be the largest id in the link:/adr/[ADR index] plus
 `tags`:: A list of tags, for classifying the ADR.
 `applies_padrs`:: List of numbers, the ids of the PADRs which this ADR applies.
 These may be added retrospectively (after the ADR is accepted).
-`superseded_by`:: The id of a later ADR which supersedes this one. 
+`superseded_by`:: The id of a later ADR which supersedes this one.
 This may be added retrospectively (after the ADR is accepted).


### PR DESCRIPTION
GitHub pages has been stuck for years on an old version of Jekyll. Updating their convenience tooling to Jekyll 4 would break a lot of existing sites, so it probably will never happen. See here for more info: https://github.com/github/pages-gem/issues/651

It turns out that we're already using the Jekyll GitHub Action (I'm not sure what the reason we've been doing that already is), so there's little reason not to upgrade.

This closes #47 by adding instructions for building locally using a container image.
This also closes #49 by adding liquid pre-processing explicitly in the file where it was missing.

See individual commit messages for more fine-grained details of other changes. Additionally, reviewing will be easier with the `?w=1` query param: https://github.com/bf2fc6cc711aee1a0c2a/architecture/pull/56/files?w=1

These changes can be seen [here](https://arch.grdryn.me/), which is build from [this branch of my fork](https://github.com/grdryn/architecture/tree/jekyll-4-grdryn), which just contains one additional commit on top of the source branch of this PR, to get everything to work nicely for the different domain, etc.