### PR TITLE
Add ADR-79 in Accepted state

### DIFF
--- a/_adr/79/index.asciidoc
+++ b/_adr/79/index.asciidoc
@@ -1,0 +1,11 @@
+---
+num: 79
+title: "Authorization for Control Planes"
+status: "Accepted"
+authors:
+  - "Miguel Soriano"
+  - "Guilherme Cassolato"
+tags: 
+  - kafka
+---
+https://docs.google.com/document/d/1LTqfQW6hKkD_Ls_YLbagTJ7FuG4AbNyGxLeUOsNWD3M/edit[Original doc]


### PR DESCRIPTION
ADR-79: Authorization for Control Planes

This ADR proposed a way to extract Authorization-related code from the Fleet Manager and perform Authorization by using [Authorino](https://github.com/kuadrant/authorino) as an [Envoy’s External Authorization Filter/Server](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter). As such, Authorino would become the Authorization layer for Control Plane services that desire Authorization.