### PR TITLE
feat: add ADR for certs management

### DIFF
--- a/_adr/5/index.asciidoc
+++ b/_adr/5/index.asciidoc
@@ -1,7 +1,8 @@
 ---
 num: 5
 title: "Kafka Cluster Certificate Generation"
-status: "Accepted"
+status: "Superseded"
+superseded_by: 31
 authors:
   - "David Ffrench"
   - "Paolo Patierno"

--- a/_adr/89/index.adoc
+++ b/_adr/89/index.adoc
@@ -1,7 +1,7 @@
 ---
 num: 89 
 title: A bf2 subdomain & wildcard certificate per data plane cluster 
-status: "Draft" # One of Draft, Accepted, Rejected
+status: "Accepted" # One of Draft, Accepted, Rejected
 authors:
   - "Manyanda Chitimbo"
   - "Steven Hawkins"

--- a/_adr/89/index.adoc
+++ b/_adr/89/index.adoc
@@ -1,0 +1,120 @@
+---
+num: 89 
+title: A bf2 subdomain & wildcard certificate per data plane cluster 
+status: "Draft" # One of Draft, Accepted, Rejected
+authors:
+  - "Manyanda Chitimbo"
+  - "Steven Hawkins"
+  - "Peter Braun"
+tags:
+  - "kafka" # e.g. kafka, connectors, registry
+applies_padrs: # What PADRs does this ADR apply?
+applies_patterns: # What APs does this ADR apply?
+---
+
+// Top style tips:
+// \* Use one sentence per line
+// \* No unexpanded acronyms
+// \* No undefined jargon
+
+// No need for a title heading, it's added by the template
+
+## Context and Problem Statement
+// What is the background against which this decision is being taken?
+The Kafka cluster deployed on the data plane cluster should be reachable via TLS.
+It means that we should provide a way to the clients to verify and validate the TLS connection with the related handshake with the Kafka brokers exposed outside of the data plane cluster.
+The Strimzi operator has its own cluster CA for signing the brokers' certificates but it should be used just for internal communication.
+This problem is the same as the one exposed https://architecture.appservices.tech/adr/5/[ADR-5: Kafka Cluster Certificate Generation] whose solution only works for managed data plane clusters but it is not an acceptable solution for when users brings / registers their own data plane clusters.
+Additionally, the proposed solution in https://architecture.appservices.tech/adr/5/[ADR-5] lacked a lot of automation on certificate management which is an area the present ADR intends to address.
+
+## Goals
+// Bulleted list of outcomes that this ADR, if accepted, should help achieve
+- Automated certificate management (generation, renewal, revocation) per data plane cluster
+- Avoid sharing same certificate between enterprise data plane clusters
+- Avoid exposing domain registrar & certificate issuers credentials onto enterprise data plane clusters 
+
+## Non-goals
+// Bulleted list of outcomes that this ADR is not trying to achieve.
+- Automated certificate management per kafka instance.
+- Creating a pattern for and/or developing a central certificate management service
+
+## Current situation
+// Where are we now?
+
+The https://architecture.appservices.tech/adr/5/[ADR-5: Kafka Cluster Certificate Generation] describes the current situation where one certificate is shared across data planes. The certificate is renewed manually using the https://github.com/bf2fc6cc711aee1a0c2a/kas-sre-sops/blob/main/sops/key_management/control_plane/dataplane_certificate.asciidoc[data plane certificate SOP]
+
+## Proposal
+// What is the decision being proposed
+The proposed solution is going to use https://Letsencrypt.org[Letsencrypt] to automatically manage certificates.
+The solution consists of: 
+
+1. Generating one wildcard certificate per data plane cluster.
+For each new data plane, there will be a wildcard certificate for the `*.<cluster-id>.kafka.bf2.dev` subdomain where `<cluster-id>` is unique for each cluster.
+2. The fleet manager in its reconcilers will use https://github.com/caddyserver/certmagic[certmagic library] to generate certificate for each data plane and store them in a secure Storage. 
+When a kafka is assigned to a given data plane, all routes created will be under the `*.<cluster-id>.kafka.bf2.dev` domain. 
+For example, if the cluster id is `mycluster` then Kafka boostrap hosts will have the form of `foobar.mycluster.kafka.bf2.dev`.
+During Kafka reconciliation between the Fleetshard and the Fleet manager, certificates will be fetched from the secure storage by the fleet manager and they'll be passed down to the data plane via the existing certificate passing mechanism i.e via the ManagedKafka CR.
+The fleet manager will implement this logic in a way that it can be easily extracted & packaged in form of a library and shared with others managed services builders.
+3. No migration to be performed for existing data plane.
+The proposed solution will be applied to only new data plane clusters.  
+Existing data plane clusters will continue to share the wildcard certificate on the `*.kafka.bf2.dev` domain.  
+The shared certificate for the already existing data planes will now be automatically renewed by the fleet manager.
+4. Certificate renewals will also be handled automatically by the fleet manager using the https://github.com/caddyserver/certmagic[certmagic library]. 
+Renewals will be blast radius aware to renew certificates in small runs.
+The intention is to reduce the risk of compromising all our certificates in case there is an outage or an issue with the renewal system in Letsencrypt. 
+It also removes the chances of bombarding Letsencrypt with bulk requests or rollout of all the Kafkas in one big batch after renewals. 
+5. Revocation will be handled per data plane cluster and it will follow a GitOps approach where SRE will request to revoke a certificate for a given data plane.
+Once the compromised certificate has been revoked, a new certificate for that data plane will be generated.
+For already existing data planes they'll continue to share the newly generated certificate: see proposal number (3). 
+6. When a data plane is removed from the fleet manager, its corresponding certificate will also be revoked. 
+If the data plane in question already existed before the solution is in place ( i.e it shares a certificate with other data plane as described in proposal number (3)), then revocation of the certifcate will only happen if there is no remaining data plane that uses it. 
+
+NOTE: There is an existing logic in the data plane that ensures that all sensitive parts in the ManagedKafka CR are not written in plain text. 
+Instead a secret is created and only references to the secrets will be added before the ManagedKafka is created in the data plane.
+
+### Threat model
+// Provide a link to the relevant threat model. 
+// You must either update an existing threat model(s) to cover the changes made by this ADR, or add a new threat model.
+
+Once the certificate are in the data plane in form of a Kubernetes secret, a priviledged users can still see them. 
+If this is on a enterprise data plane cluster without good security standards/policy, then anyone with the private key can impersonate the server or eavesdrop on a connection with the server. 
+For non enterprise data plane clusters, this is mitigated by only allowing SREs to have the priviledge / permissions to see these secrets.
+For enterprise data plane clusters, customers will be advised to do so as well.
+
+Morever, since there will be a different certificate per data plane clusters, if one certificate is compromised, it won't affect others and it can be safely revoked. 
+The proposed solution also limits the possibility of an owner of a enterprise data plane cluster, eavesdropping on another data plane cluster that they do not own as the certificate keys will be different. 
+
+NOTE: If the shared certificate for an existing data plane cluster is to be compromised, then it opens up a securiry risk on all the Kafkas on these existing data plane clusters. However, the chances of this security breach occurring is mitigateg by first and foremost ensuring only SREs have priviledged access to data plane clusters. And second, if a the security issue is detected then certificates can be easily revoked via the GitOps flow and new ones autocreated 
+
+## Alternatives Considered / Rejected
+
+1. Deploying https://www.redhat.com/sysadmin/cert-manager-operator-openshift[cert-manager operator] to the data plane. Rejected to avoid exposing domain registrar credentials and to avoid adding another component that consumes data plane resources and that needs to be monitored.
+
+2. Migrating existing data plane (and their Kafkas). This change is disruptive to existing customers hence why it was rejected. 
+The Kafka fleet manager will thus ensure that existing Kafkas on existing data planes clusters continue to operate using a shared wildcard certificate on the `*.kafka.bf2.dev` domain i.e the proposed solution will only be applied to new data plane clusters.
+
+3. Deploying https://www.redhat.com/sysadmin/cert-manager-operator-openshift[cert-manager operator] in the Control Plane. 
+The Control plane then handles the pushing of the Certificate request CR, watching for the created secrets and storing them securely. 
+Rejected because this is technically complex and has no clear benefit over the propsed solution of using a library.
+It also violates the design intentions of the fleet manager by turning into an Kubernetes operator. 
+Finally, it's another component deployed that has to be monitored and managed in the control plane which forces every one (especially dev environments) to have a running Kubernetes cluster running during development
+
+## Challenges
+// What are the costs/drawbacks of the proposed decision?
+1. The drawback is that the solution can't or won't handle the migration of already existing data plane clusters that have Kafkas on them.
+This is based on the fact that the proposal intends to make this change a transparent one to existing Kafka instances. 
+For this, the Kafka fleet manager will ensure that existing data planes clusters continue to operate using a shared wildcard certificate on the `\*.kafka.bf2.dev` domain. 
+All new data planes will have a wildcard certificate on the `*.<cluster-id>.kafka.bf2.dev` subdomain where the `cluster-id` is unique for each data plane.
+2. Reaching the various advertised https://Letsencrypt.org/docs/rate-limits/[Letsencrypt limits] is also a challenge.
+However, the various limits once reached can be overridden via a request as described in https://Letsencrypt.org/docs/rate-limits/#a-id-overrides-a-overrides[Letsencrypt limits overrides] 
+
+## Dependencies
+// What are the knock-on effects if this decision is accepted?
+
+Depedency on Letsencyrpt and its limits e.g a 50 certificates limits per domain per week 
+
+## Consequences if not completed
+// What are the knock-on effects if this decision is not accepted?
+
+1. Living up with the toil related to the manual certificate handling. 
+2. Certificate shared between data planes and potentially exposing it to customers the data planes.


### PR DESCRIPTION
The ADR intends to supersede https://architecture.appservices.tech/adr/5/