### PR TITLE
fix(adr): aDR 5 is superseded by 89 and not 31

### DIFF
--- a/_adr/5/index.asciidoc
+++ b/_adr/5/index.asciidoc
@@ -2,7 +2,7 @@
 num: 5
 title: "Kafka Cluster Certificate Generation"
 status: "Superseded"
-superseded_by: 31
+superseded_by: 89
 authors:
   - "David Ffrench"
   - "Paolo Patierno"


### PR DESCRIPTION
@emmanuelbernard I noticed a small mistake in the ADR number and thus the generated link does not work correct. 
I hope this does indeed fix it as it uses the correct ADR number.