### PR TITLE
Add config file for bf2-arch-bot

### DIFF
--- a/.github/bf2-arch-bot.yml
+++ b/.github/bf2-arch-bot.yml
@@ -1,0 +1,13 @@
+# Github login name of the bot itself
+botUserLogin: bf2-arch-bot
+
+# The time, in hours, to wait between checking for stalled discussions
+# 1440 minutes = 24 hours
+stalledDiscussionPollTimeMins: 1440
+
+# Github logins of people who can do "/create adr" etc on issues
+recordCreationApprovers:
+- emmanuelbernard
+- tombentley
+
+publishedUrl: https://architecture.appservices.tech


### PR DESCRIPTION
@tombentley I think the absence of this config is why the CreateDraftRecordFlow wasn't working when we deployed the bot:

```
2023-01-26 14:20:00,294 ERROR [io.qua.githubapp] (executor-thread-9) Error handling delivery 837d6330-9d84-11ed-80e9-b0f18184024a
› Repository: bf2fc6cc711aee1a0c2a/architecture
› Event: issue_comment.created
› Context: https://github.com/bf2fc6cc711aee1a0c2a/architecture/issues/87#issuecomment-1405072257
› Redeliver: https://github.com/settings/apps/bf2-arch-bot/advanced
Exception: java.util.concurrent.CompletionException: java.lang.IllegalStateException: Repo is missing config file
at io.quarkus.arc.impl.EventImpl.handleExceptions(EventImpl.java:205)
at io.quarkus.arc.impl.EventImpl$1.get(EventImpl.java:102)
at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
at io.quarkus.vertx.core.runtime.VertxCoreRecorder$13.runWith(VertxCoreRecorder.java:543)
at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)
at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.IllegalStateException: Repo is missing config file
at org.bf2.arch.bot.CreateDraftRecordFlow.onIssueComment(CreateDraftRecordFlow.java:88)
at org.bf2.arch.bot.CreateDraftRecordFlow_Multiplexer.onIssueComment_9c21b751bd1c3c76c9e9f8d4cbcacbc05e9e7ed7(Unknown Source)
at org.bf2.arch.bot.CreateDraftRecordFlow_Multiplexer_Observer_onIssueComment_9c21b751bd1c3c76c9e9f8d4cbcacbc05e9e7ed7_b0c9bd97028602d77bb976e151881cadfe8eb668.notify(Unknown Source)
at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:320)
at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:302)
at io.quarkus.arc.impl.EventImpl$1.get(EventImpl.java:101)
... 8 more
```